### PR TITLE
Update redis_

### DIFF
--- a/redis_
+++ b/redis_
@@ -6,7 +6,7 @@
 #%# capabilities=autoconf suggest
 
 ip_socket=$(echo $0 | awk -F_ '{ print $2 }')
-if [ $ip_socket = "socket" ]; then
+if [[ $ip_socket = "socket" ]]; then
 tmp_var=$(echo $0 | awk -F_ '{ s = ""; for (i = 3; i <= NF; i++) s = s $i "/"; print s }')
 port_path=$(echo "/${tmp_var}" | sed 's,/$,,')
 else


### PR DESCRIPTION
Fixes `./redis_: line 9: [: =: unary operator expected` error.