### PR TITLE
Errors in logs : no label available

### DIFF
--- a/redis_
+++ b/redis_
@@ -195,12 +195,14 @@ if [ "$1" = "config" ]; then
         print "graph_info Number of keys per dbs";
 
         for (i in dbskeys)
-            print i "keys.label " i " keys"
+            print i ""
+            print i "keys.label keys"
             print i "keys.type GAUGE"
             print i "keys.min 0"
 
         for (i in dbsexpires)
-            print i "expires.label " i " keys with TTL"
+            print i ""
+            print i "expires.label keys with TTL"
             print i "expires.type GAUGE"
             print i "expires.min 0";
     };


### PR DESCRIPTION
In munin logs there is : 
```
2022/04/13 08:50:41 [WARNING] Service redis_ returned no data for label keys
2022/04/13 08:50:41 [WARNING] Service redis_ returned no data for label expires
```
Solve this
